### PR TITLE
Build analyser library as .NET Standard instead

### DIFF
--- a/Bluewire.Analysers/Bluewire.Analysers.csproj
+++ b/Bluewire.Analysers/Bluewire.Analysers.csproj
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net47</TargetFrameworks>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="*.ncrunchproject" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all">
       <Version>2.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all">
       <Version>2.10.0</Version>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Omit referenced binaries, since the analyser host process should supply
these.